### PR TITLE
Revert "Skip DCO requirement for repository owner"

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,5 +1,2 @@
-require:
-  members: false
-
 allowRemediationCommits:
   individual: true


### PR DESCRIPTION
This reverts commit cd1df26960409832ca89a4e6a54548aceb2cda31.